### PR TITLE
Upgrade to MaxScale 6.1.3 and MariaDB's official image

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,12 +28,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           push: true

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,41 @@
+name: Build image and push to GHCR
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM docker.io/library/centos:7@sha256:c2f1d5a9c0a81350fa0ad7e1eee99e379d75fe53823d44b5469eb2eb6092c941
+FROM docker.io/library/centos:8
 
-ENV MAXSCALE_VERSION=2.2.20
+ENV MAXSCALE_VERSION=6.1.3
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN yum install -y https://downloads.mariadb.com/MaxScale/${MAXSCALE_VERSION}/centos/7/x86_64/maxscale-${MAXSCALE_VERSION}-1.centos.7.x86_64.rpm && \
+RUN yum install -y https://downloads.mariadb.com/MaxScale/${MAXSCALE_VERSION}/centos/8/x86_64/maxscale-${MAXSCALE_VERSION}-1.rhel.8.x86_64.rpm && \
     yum clean all -y && \
     chmod g=u /etc/passwd && \
     chmod +x entrypoint.sh && \
-    chmod -R g=u /var/{lib,run}/maxscale && \
-    chgrp -R 0 /var/{lib,run}/maxscale
+    chmod -R g=u /var/{lib,run,log,cache}/maxscale && \
+    chgrp -R 0 /var/{lib,run,log,cache}/maxscale
+
 
 COPY maxscale.cnf /etc/maxscale.cnf
 
@@ -20,8 +21,8 @@ CMD ["maxscale", "--nodaemon", "--log=stdout"]
 
 EXPOSE 6603 3306 3307 8003
 
-ENV THREADS=2 \
-    SERVICE_USER=maxscale \
+ENV SERVICE_USER=maxscale \
+    SERVICE_PWD=asdf1234 \
     READ_WRITE_LISTEN_ADDRESS=127.0.0.1 \
     READ_WRITE_PORT=3307 \
     READ_WRITE_PROTOCOL=MariaDBClient \
@@ -29,8 +30,12 @@ ENV THREADS=2 \
     MASTER_ONLY_PORT=3306 \
     MASTER_ONLY_PROTOCOL=MariaDBClient \
     MONITOR_USER=maxscale \
-    AUTH_CONNECT_TIMEOUT=10 \
-    AUTH_READ_TIMEOUT=10 \
+    MONITOR_PWD=asdf123 \
+    AUTH_CONNECT_TIMEOUT=10s \
+    AUTH_READ_TIMEOUT=10s \
+    DB1_ADDRESS=db1.example.org \
+    DB2_ADDRESS=db2.example.org \
+    DB3_ADDRESS=db3.example.org \
     DB1_PORT=3306 \
     DB2_PORT=3306 \
     DB3_PORT=3306 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM docker.io/library/centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
-
-ENV MAXSCALE_VERSION=6.1.3
+FROM docker.io/mariadb/maxscale:6.1.3
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN yum install -y https://downloads.mariadb.com/MaxScale/${MAXSCALE_VERSION}/centos/8/x86_64/maxscale-${MAXSCALE_VERSION}-1.rhel.8.x86_64.rpm && \
+RUN yum remove -y rsyslog monit && \
     yum clean all -y && \
     chmod g=u /etc/passwd && \
     chmod +x entrypoint.sh && \
@@ -14,7 +12,7 @@ RUN yum install -y https://downloads.mariadb.com/MaxScale/${MAXSCALE_VERSION}/ce
 
 COPY maxscale.cnf /etc/maxscale.cnf
 
-USER 1001
+USER 998
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["maxscale", "--nodaemon", "--log=stdout"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:8
+FROM docker.io/library/centos:8@sha256:a27fd8080b517143cbbbab9dfb7c8571c40d67d534bbdee55bd6c473f432b177
 
 ENV MAXSCALE_VERSION=6.1.3
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # MaxScale in Docker
 
-[![Docker Build Status](https://img.shields.io/docker/build/appuio/maxscale-docker.svg)](https://hub.docker.com/r/appuio/maxscale-docker/)
-
 Dockerized MariaDB MaxScale with default config for a three node galera cluster. Various settings can be configured with environemnt variables.
 
 ## Run
 You need to specify the addresses for DB1 through DB3 as well as passwords for service and monitoring users:
 ```
-docker run -e DB1_ADDRESS=127.0.0.1 -e DB2_ADDRESS=127.0.0.2 -e DB3_ADDRESS=127.0.0.3 -e SERVICE_PWD="SuperSecret1234" -e MONITOR_PWD="EvenMoreSecret" maxscale:2.1.1
+docker run -e DB1_ADDRESS=127.0.0.1 -e DB2_ADDRESS=127.0.0.2 -e DB3_ADDRESS=127.0.0.3 -e SERVICE_PWD="SuperSecret1234" -e MONITOR_PWD="EvenMoreSecret" quay.io/maxscale:6.1.3
 ```
 ## Configuration
 Config is done through env vars:
@@ -24,8 +22,6 @@ Config is done through env vars:
 | `MASTER_ONLY_PROTOCOL`        | `MariaDBClient`     | Protocol for master onyl service        |
 | `MONITOR_USER`                | `maxscale`          | Monitoring user                         |
 | `MONITOR_PWD`                 |                     | Password for the monitoring user        |
-| `AUTH_CONNECT_TIMEOUT`        | `10s`               | Value for [`auth_connect_timeout`][]    |
-| `AUTH_READ_TIMEOUT`           | `10s`               | Value for [`auth_read_timeout`][]       |
 | `DB1_ADDRESS`                 | `db1.example.org`   | Address for backend DB1                 |
 | `DB1_PORT`                    | `3306`              | Port for backend DB1                    |
 | `DB1_PRIO`                    | `1`                 | Priority for backend DB1                |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Config is done through env vars:
 
 | Name                          | Default value       | Description                             |
 |-------------------------------|---------------------|-----------------------------------------|
-| `THREADS`                     | `2`                 | Thread count to run MaxScale            |
 | `SERVICE_USER`                | `maxscale`          | Service user                            |
 | `SERVICE_PWD`                 |                     | Password for the service user           |
 | `READ_WRITE_LISTEN_ADDRESS`   | `127.0.0.1`         | Listen address for read/write service   |
@@ -25,15 +24,15 @@ Config is done through env vars:
 | `MASTER_ONLY_PROTOCOL`        | `MariaDBClient`     | Protocol for master onyl service        |
 | `MONITOR_USER`                | `maxscale`          | Monitoring user                         |
 | `MONITOR_PWD`                 |                     | Password for the monitoring user        |
-| `AUTH_CONNECT_TIMEOUT`        | `10`                | Value for [`auth_connect_timeout`][]    |
-| `AUTH_READ_TIMEOUT`           | `10`                | Value for [`auth_read_timeout`][]       |
-| `DB1_ADDRESS`                 |                     | Address for backend DB1                 |
+| `AUTH_CONNECT_TIMEOUT`        | `10s`               | Value for [`auth_connect_timeout`][]    |
+| `AUTH_READ_TIMEOUT`           | `10s`               | Value for [`auth_read_timeout`][]       |
+| `DB1_ADDRESS`                 | `db1.example.org`   | Address for backend DB1                 |
 | `DB1_PORT`                    | `3306`              | Port for backend DB1                    |
 | `DB1_PRIO`                    | `1`                 | Priority for backend DB1                |
-| `DB2_ADDRESS`                 |                     | Address for backend DB2                 |
+| `DB2_ADDRESS`                 | `db2.example.org`   | Address for backend DB2                 |
 | `DB2_PORT`                    | `3306`              | Port for backend DB2                    |
 | `DB2_PRIO`                    | `2`                 | Priority for backend DB2                |
-| `DB3_ADDRESS`                 |                     | Address for backend DB3                 |
+| `DB3_ADDRESS`                 | `db3.example.org`   | Address for backend DB3                 |
 | `DB3_PORT`                    | `3306`              | Port for backend DB3                    |
 | `DB3_PRIO`                    | `3`                 | Priority for bakcend DB3                |
 
@@ -41,13 +40,13 @@ Config is done through env vars:
 To use a complete custom config, mount your own config file to `/etc/maxscale.cnf`:
 
 ```
-docker run -v /home/customfile.cnf:/etc/maxscale.cnf maxscale:2.1.1
+docker run -v /home/customfile.cnf:/etc/maxscale.cnf maxscale:6.1.3
 ```
 
 ## Build
 ```
-docker build --rm -t registry.vshn.net/vshn-docker/maxscale:2.2.1 .
-docker push registry.vshn.net/vshn-docker/maxscale:2.2.1
+docker build --rm -t registry.vshn.net/vshn-docker/maxscale:6.1.3 .
+docker push registry.vshn.net/vshn-docker/maxscale:6.1.3:
 ```
 
 ## OpenShift

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -v /home/customfile.cnf:/etc/maxscale.cnf maxscale:6.1.3
 ## Build
 ```
 docker build --rm -t registry.vshn.net/vshn-docker/maxscale:6.1.3 .
-docker push registry.vshn.net/vshn-docker/maxscale:6.1.3:
+docker push registry.vshn.net/vshn-docker/maxscale:6.1.3
 ```
 
 ## OpenShift

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ To use a complete custom config, mount your own config file to `/etc/maxscale.cn
 docker run -v /home/customfile.cnf:/etc/maxscale.cnf maxscale:6.1.3
 ```
 
-## Build
+### Build
+
+A plain build will use the defaults from the table above:
+
 ```
-docker build --rm -t registry.vshn.net/vshn-docker/maxscale:6.1.3 .
-docker push registry.vshn.net/vshn-docker/maxscale:6.1.3
+docker build .
 ```
 
 ## OpenShift

--- a/maxscale.cnf
+++ b/maxscale.cnf
@@ -1,13 +1,14 @@
-[MaxScale]
+[maxscale]
 substitute_variables=true
 syslog=0
-threads=$THREADS
-auth_connect_timeout=$AUTH_CONNECT_TIMEOUT
-auth_read_timeout=$AUTH_READ_TIMEOUT
+# Variable substitution in the maxscale section seems broken,
+# so these are hardcoded now.
+auth_connect_timeout=10s
+auth_read_timeout=10s
 
 [ReadWriteSplit-Service]
 localhost_match_wildcard_host=1
-passwd=$SERVICE_PWD
+password=$SERVICE_PWD
 router=readwritesplit
 servers=db1,db2,db3
 type=service
@@ -22,7 +23,7 @@ type=listener
 
 [MasterOnly-Service]
 localhost_match_wildcard_host=1
-passwd=$SERVICE_PWD
+password=$SERVICE_PWD
 router_options=master
 router=readconnroute
 servers=db1,db2,db3
@@ -38,34 +39,12 @@ type=listener
 
 [Galera-Monitor]
 module=galeramon
-passwd=$MONITOR_PWD
+password=$MONITOR_PWD
 servers=db1,db2,db3
 type=monitor
 use_priority=true
 user=$MONITOR_USER
 disable_master_failback=false
-
-[MaxInfo]
-type=service
-router=maxinfo
-user=monitor
-passwd=$SERVICE_PWD
-
-[MaxInfo-JSON-Listener]
-type=listener
-service=MaxInfo
-protocol=HTTPD
-port=8003
-
-[CLI]
-type=service
-router=cli
-
-[CLI-Listener]
-type=listener
-service=CLI
-protocol=maxscaled
-socket=default
 
 [db1]
 type=server


### PR DESCRIPTION
Upgrades MaxScale to 6.1.3 and switches to MaxScale's official image as a base.

Changes:

  * Variable substitution seems to no longer work in the `[maxscale]` section despite `substitute_variables=true` being the first option. Therefore `auth_connect_timeout` and `auth_read_timeout` are hardcoded to 10s
  * `threads` is `auto` by default in MaxScale 6 and higher. Because of the substitution problem, it seems impossible to set it from an env var. So I've removed the option from maxscale.cnf for now
